### PR TITLE
Fix translator key gaps and voice-channel localization metadata

### DIFF
--- a/cogs/manage.py
+++ b/cogs/manage.py
@@ -71,8 +71,8 @@ class Create_Group(GroupCog, name=T("create")):
             "fr": {
                 "bot_perms": "Gérer les canels",
                 "member_perms": "Gérer les canels",
-                "name": "Créer un canel textuel",
-                "description": "Créer un canel textuel",
+                "name": "Créer un canal vocal",
+                "description": "Créer un canal vocal",
                 "parameters": [
                     {
                         "name": "Nom",
@@ -104,17 +104,12 @@ class Create_Group(GroupCog, name=T("create")):
             "de": {
                 "bot_perms": "Kanäle verwalten",
                 "member_perms": "Kanäle verwalten",
-                "name": "Textkanal erstellen",
-                "description": "Einen Textkanal erstellen",
+                "name": "Sprachkanal erstellen",
+                "description": "Einen Sprachkanal erstellen",
                 "parameters": [
                     {
                         "name": "Name",
                         "description": "Wie werden Sie ihn nennen?",
-                        "required": False,
-                    },
-                    {
-                        "name": "Thema",
-                        "description": "Was ist das Thema des Kanals?",
                         "required": False,
                     },
                     {
@@ -123,13 +118,8 @@ class Create_Group(GroupCog, name=T("create")):
                         "required": False,
                     },
                     {
-                        "name": "Slowmode",
-                        "description": "Was ist der Slowmode (1h, 30m, etc.) (Max 6 Stunden)",
-                        "required": False,
-                    },
-                    {
-                        "name": "NSFW aktiviert",
-                        "description": "Soll es ein NSFW-Kanal sein?",
+                        "name": "Benutzer",
+                        "description": "Wie viele Benutzer können beitreten? (Max 99)",
                         "required": False,
                     },
                 ],

--- a/languages/Translator.py
+++ b/languages/Translator.py
@@ -617,6 +617,12 @@ class MyTranslator(Jeanne.Translator):
                 "fr": "sticker",
                 "de": "aufkleber",
             },
+            "sticker_parm_name": {
+                "en-GB": "sticker",
+                "en-US": "sticker",
+                "fr": "sticker",
+                "de": "aufkleber",
+            },
             "sticker_parm_desc": {
                 "en-GB": "Insert message ID with the sticker or name of the sticker in the server",
                 "en-US": "Insert message ID with the sticker or name of the sticker in the server",
@@ -967,6 +973,12 @@ class MyTranslator(Jeanne.Translator):
                 "en-US": "role",
                 "fr": "rôle",
                 "de": "rolle",
+            },
+            "image_parm_name": {
+                "en-GB": "image",
+                "en-US": "image",
+                "fr": "image",
+                "de": "bild",
             },
             "image_parm_desc": {
                 "en-GB": "Add an image",
@@ -1324,7 +1336,18 @@ class MyTranslator(Jeanne.Translator):
                 "fr": "cloner",
                 "de": "klonen",
             },
-            "remove_name": {"en-GB": "remove", "en-US": "remove", "fr": "supprimer"},
+            "remove_name": {
+                "en-GB": "remove",
+                "en-US": "remove",
+                "fr": "supprimer",
+                "de": "entfernen",
+            },
+            "remove": {
+                "en-GB": "remove",
+                "en-US": "remove",
+                "fr": "supprimer",
+                "de": "entfernen",
+            },
             "remove_role_description": {
                 "en-GB": "Remove a role from a member",
                 "en-US": "Remove a role from a member",
@@ -1444,6 +1467,12 @@ class MyTranslator(Jeanne.Translator):
                 "en-US": "role",
                 "fr": "rôle",
                 "de": "rolle",
+            },
+            "remove_role_reward_name": {
+                "en-GB": "remove",
+                "en-US": "remove",
+                "fr": "supprimer",
+                "de": "entfernen",
             },
             "remove_role_reward_description": {
                 "en-GB": "Remove a role reward for a level",
@@ -1624,6 +1653,12 @@ class MyTranslator(Jeanne.Translator):
                 "en-US": "What is the message ID?",
                 "fr": "Quel est l'ID du message?",
                 "de": "Was ist die Nachrichten-ID?",
+            },
+            "thread": {
+                "en-GB": "thread",
+                "en-US": "thread",
+                "fr": "fil",
+                "de": "thread",
             },
             "public_thread_description": {
                 "en-GB": "Make a public thread",


### PR DESCRIPTION
### Motivation
- Fix mismatches between command metadata and translations so localization works correctly and voice-channel command text isn't copy-pasted from text-channel metadata.
- Add missing translator keys referenced by `cogs/manage.py` to avoid runtime translation lookups failing.

### Description
- Updated French and German `voicechannel` command metadata in `cogs/manage.py` to use voice-channel wording and correct parameter labels (`name`, `catégorie`/`Kategorie`, `users`/`Benutzer`).
- Added missing translator entries to `languages/Translator.py`: `sticker_parm_name`, `image_parm_name`, `remove`, `remove_role_reward_name`, and `thread`.
- Expanded `remove_name` to include a German translation and added a `remove` alias key for consistency with how `cogs/manage.py` references `T("remove")`.
- Ensured all `T("...")` keys used in `cogs/manage.py` are present in the translator dictionary and kept translations consistent across `en-GB`, `en-US`, `fr`, and `de` where applicable.

### Testing
- Ran `python -m py_compile languages/Translator.py cogs/manage.py` and the files compiled without syntax errors (success).
- Executed an automated check script that collects all `T("...")` keys used in `cogs/manage.py` and verified every key exists in the translator dictionary (no missing keys found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999b8556ea0832da0473f001c5a9002)